### PR TITLE
Two Step Init

### DIFF
--- a/src/lin_bus.cpp
+++ b/src/lin_bus.cpp
@@ -1,7 +1,7 @@
 #include "Arduino.h"
 #include "lin_bus.h"
 
-LIN::LIN(HardwareSerial* stream, uint16_t baudrate, uint8_t break_characters) {
+void LIN::begin(HardwareSerial* stream, uint16_t baudrate, uint8_t break_characters) {
   (*stream).begin(baudrate);
   this->_stream = stream;
   

--- a/src/lin_bus.h
+++ b/src/lin_bus.h
@@ -45,7 +45,9 @@ public:
   #define lin2x 2
   
   // Constructor for Node
-  LIN(HardwareSerial* stream, uint16_t baudrate, uint8_t break_characters = 13);
+  LIN(HardwareSerial* stream, uint16_t baudrate, uint8_t break_characters = 13) {begin(stream, baudrate, break_characters);}
+  LIN() {_stream = 0; }
+  void begin(HardwareSerial* stream, uint16_t baudrate, uint8_t break_characters = 13);
   void order(byte PID, byte* message, int length, int checksumtype = 1);
   int response(byte PID, byte* message, int length, int checksumtype = 1);
   


### PR DESCRIPTION
When Teensduino 1.58 was released, the user @skpang, was having problems with this library faulting at startup.
I have run into this in the past where modifying the hardware in the constructer of a global object, can sometimes work and some times not, depending on the order in which the hardware is initialized and the order of constructors and the like. 

So I did a quick and dirty, where I renamed your constructor to void method begin with the same parameters. 
I left the full constructor in the header file and have it call begin.  But in addition I added an empty constructor with no parameters.

He then updated is sketch to use this constructor and call the begin in the setup() function and it now works.
The conversation is up on the Teensy forum in the thread:
https://forum.pjrc.com/threads/72509-Teensyduino-1-58-Released?p=323576&viewfull=1#post323576

Feel free to use or not use... Just tried to help him get things up and running again.